### PR TITLE
Address up to 256 LED per channel

### DIFF
--- a/light_ws2812.c
+++ b/light_ws2812.c
@@ -92,19 +92,9 @@ void ws2812_sendarray(uint8_t *data,uint16_t datlen)
 #define w_nop8  w_nop4 w_nop4
 #define w_nop16 w_nop8 w_nop8
 
-void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
-{
-  uint8_t curbyte,ctr,masklo;
-  uint8_t sreg_prev;
-  
-  masklo	=~maskhi&ws2812_PORTREG;
-  maskhi |=        ws2812_PORTREG;
-  sreg_prev=SREG;
-  cli();  
+inline void send_byte(uint8_t curbyte, uint8_t maskhi, uint8_t masklo){
+    uint8_t ctr;
 
-  while (datlen--) {
-    curbyte=*data++;
-    
     asm volatile(
     "       ldi   %0,8  \n\t"
     "loop%=:            \n\t"
@@ -164,6 +154,57 @@ w_nop16
     :	"=&d" (ctr)
     :	"r" (curbyte), "I" (_SFR_IO_ADDR(ws2812_PORTREG)), "r" (maskhi), "r" (masklo)
     );
+}
+
+void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
+{
+  uint8_t curbyte, masklo;
+  uint8_t sreg_prev;
+  
+  masklo	=~maskhi&ws2812_PORTREG;
+  maskhi |=        ws2812_PORTREG;
+  sreg_prev=SREG;
+  cli();  
+
+  while (datlen--) {
+    curbyte=*data++;
+    send_byte(curbyte, maskhi, masklo);
+  }
+  
+  SREG=sreg_prev;
+}
+
+void inline ws2812_sendarraylow_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
+{
+  uint8_t curbyte, masklo;
+  uint8_t sreg_prev;
+  
+  masklo	=~maskhi&ws2812_PORTREG;
+  maskhi |=        ws2812_PORTREG;
+  sreg_prev=SREG;
+  cli();  
+
+  while (datlen--) {
+    curbyte=*data++;
+    send_byte(curbyte<<4, maskhi, masklo);
+  }
+  
+  SREG=sreg_prev;
+}
+
+void inline ws2812_sendarrayhigh_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
+{
+  uint8_t curbyte, masklo;
+  uint8_t sreg_prev;
+  
+  masklo	=~maskhi&ws2812_PORTREG;
+  maskhi |=        ws2812_PORTREG;
+  sreg_prev=SREG;
+  cli();  
+
+  while (datlen--) {
+    curbyte=*data++;
+    send_byte(curbyte&240, maskhi, masklo);
   }
   
   SREG=sreg_prev;

--- a/light_ws2812.h
+++ b/light_ws2812.h
@@ -48,6 +48,8 @@ void ws2812_setleds_pin(struct cRGB *ledarray, uint16_t number_of_leds,uint8_t p
 
 void ws2812_sendarray     (uint8_t *array,uint16_t length);
 void ws2812_sendarray_mask(uint8_t *array,uint16_t length, uint8_t pinmask);
+void ws2812_sendarraylow_mask(uint8_t *array,uint16_t length, uint8_t pinmask);
+void ws2812_sendarrayhigh_mask(uint8_t *array,uint16_t length, uint8_t pinmask);
 
 
 /*

--- a/main.cpp
+++ b/main.cpp
@@ -42,13 +42,13 @@ extern "C"
 /* ----------------------------- LED interface ----------------------------- */
 /* ------------------------------------------------------------------------- */
 
-#define MAX_LEDS		64
+#define MAX_LEDS		128
 #define MIN_LED_FRAME	8 * 3
 #define DELAY_CYCLES	64
 
 static uint8_t led[MAX_LEDS * 3];
 
-const PROGMEM uint16_t ledDataCount[] = {MIN_LED_FRAME, MIN_LED_FRAME * 2, MIN_LED_FRAME * 4, MIN_LED_FRAME * 8 };
+const PROGMEM uint16_t ledDataCount[] = {MIN_LED_FRAME, MIN_LED_FRAME * 2, MIN_LED_FRAME * 4, MIN_LED_FRAME * 8, MAX_LEDS * 3};
 
 /* 
 	Reports:
@@ -61,6 +61,7 @@ const PROGMEM uint16_t ledDataCount[] = {MIN_LED_FRAME, MIN_LED_FRAME * 2, MIN_L
 		7: LED Frame [Channel, [G, R, B][0..15]]
 		8: LED Frame [Channel, [G, R, B][0..31]]
 		9: LED Frame [Channel, [G, R, B][0..63]]
+		10: LED Frame [Channel, [G, R, B][0..127]]
 	
 	Memory Map:
 		00      : Oscillator calibration value
@@ -80,62 +81,64 @@ const PROGMEM uint16_t ledDataCount[] = {MIN_LED_FRAME, MIN_LED_FRAME * 2, MIN_L
 
 const PROGMEM char usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH] = {    /* USB report descriptor */
 
-    0x06, 0x00, 0xff,              // USAGE_PAGE (Generic Desktop)
-    0x09, 0x01,                    // USAGE (Vendor Usage 1)
-    0xa1, 0x01,                    // COLLECTION (Application)
-    0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-    0x26, 0xff, 0x00,              //   LOGICAL_MAXIMUM (255)
-    0x75, 0x08,                    //   REPORT_SIZE (8)
-    0x85, 0x01,                    //   REPORT_ID (1)
-    0x95, 0x03,                    //   REPORT_COUNT (3)
-    0x09, 0x00,                    //   USAGE (Undefined)
-    0xb2, 0x02, 0x01,              //   FEATURE (Data,Var,Abs,Buf)
-    0x85, 0x02,                    //   REPORT_ID (2)
-    0x95, 0x20,                    //   REPORT_COUNT (32)
-    0x09, 0x00,                    //   USAGE (Undefined)
-    0xb2, 0x02, 0x01,              //   FEATURE (Data,Var,Abs,Buf)
-    0x85, 0x03,                    //   REPORT_ID (3)
-    0x95, 0x20,                    //   REPORT_COUNT (32)
-    0x09, 0x00,                    //   USAGE (Undefined)
-    0xb2, 0x02, 0x01,              //   FEATURE (Data,Var,Abs,Buf)
-    0x85, 0x04,                    //   REPORT_ID (4)
-    0x95, 0x01,                    //   REPORT_COUNT (1)
-    0x09, 0x00,                    //   USAGE (Undefined)
-    0xb2, 0x02, 0x01,              //   FEATURE (Data,Var,Abs,Buf)
-    0x85, 0x05,                    //   REPORT_ID (5)
-    0x95, 0x05,                    //   REPORT_COUNT (5)
-    0x09, 0x00,                    //   USAGE (Undefined)
-    0xb2, 0x02, 0x01,              //   FEATURE (Data,Var,Abs,Buf)
-    0x85, 0x06,                    //   REPORT_ID (6)
-    0x95, MIN_LED_FRAME + 1,       //   REPORT_COUNT (25)
-    0x09, 0x00,                    //   USAGE (Undefined)
-    0xb2, 0x02, 0x01,              //   FEATURE (Data,Var,Abs,Buf)
-    0x85, 0x07,                    //   REPORT_ID (7)
-    0x95, MIN_LED_FRAME * 2 + 1,   //   REPORT_COUNT (49)
-    0x09, 0x00,                    //   USAGE (Undefined)
-    0xb2, 0x02, 0x01,              //   FEATURE (Data,Var,Abs,Buf)
-    0x85, 0x08,                    //   REPORT_ID (8)
-    0x95, MIN_LED_FRAME * 4 + 1,   //   REPORT_COUNT (97)
-    0x09, 0x00,                    //   USAGE (Undefined)
-    0xb2, 0x02, 0x01,              //   FEATURE (Data,Var,Abs,Buf)
-    0x85, 0x09,                    //   REPORT_ID (9)
-    0x95, MIN_LED_FRAME * 8 + 1,   //   REPORT_COUNT (193)
-    0x09, 0x00,                    //   USAGE (Undefined)
-    0xb2, 0x02, 0x01,              //   FEATURE (Data,Var,Abs,Buf)
-    0xc0                           // END_COLLECTION
+    '\x06', '\x00', '\xff',          // USAGE_PAGE (Generic Desktop)
+    '\x09', '\x01',                  // USAGE (Vendor Usage 1)
+    '\xa1', '\x01',                  // COLLECTION (Application)
+    '\x15', '\x00',                  //   LOGICAL_MINIMUM (0)
+    '\x26', '\xff', '\x00',          //   LOGICAL_MAXIMUM (255)
+    '\x75', '\x08',                  //   REPORT_SIZE (8)
+    '\x85', '\x01',                  //   REPORT_ID (1)
+    '\x95', '\x03',                  //   REPORT_COUNT (3)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\x85', '\x02',                  //   REPORT_ID (2)
+    '\x95', '\x20',                  //   REPORT_COUNT (32)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\x85', '\x03',                  //   REPORT_ID (3)
+    '\x95', '\x20',                  //   REPORT_COUNT (32)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\x85', '\x04',                  //   REPORT_ID (4)
+    '\x95', '\x01',                  //   REPORT_COUNT (1)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\x85', '\x05',                  //   REPORT_ID (5)
+    '\x95', '\x05',                  //   REPORT_COUNT (5)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\x85', '\x06',                  //   REPORT_ID (6)
+    '\x95', '\x19',                  //   REPORT_COUNT (25)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\x85', '\x07',                  //   REPORT_ID (7)
+    '\x95', '\x31',                  //   REPORT_COUNT (49)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\x85', '\x08',                  //   REPORT_ID (8)
+    '\x95', '\x61',                  //   REPORT_COUNT (97)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\x85', '\x09',                  //   REPORT_ID (9)
+    '\x96', '\xc1',                  //   REPORT_COUNT (193)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\x85', '\x0a',                  //   REPORT_ID (10)
+    '\x96', '\x81', '\x01',          //   REPORT_COUNT (385)
+    '\x09', '\x00',                  //   USAGE (Undefined)
+    '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
+    '\xc0'                           // END_COLLECTION
 };
 
-static uchar currentAddress;
-static uchar addressOffset;
-static uchar bytesRemaining;
+static uint16_t currentAddress;
+static uint16_t bytesRemaining;
 static uchar reportId = 0; 
 static uchar channel;
 
 static uint8_t mode;
 static uint8_t task = 0;
 static uint16_t ledCount = 0;
-static uint16_t ledIndex = 0;
-static uint16_t delayCycles = 0;
+static uint8_t delayCycles = 0;
 
 /* ------------------------------------------------------------------------- */
 /* ----------------------------- Helper Functions--------------------------- */
@@ -185,11 +188,12 @@ uchar usbFunctionRead(uchar *data, uchar len)
 		if(len > bytesRemaining)
 			len = bytesRemaining;
 
+                uint8_t addressOffset = reportId==2 ? 32 : 64;
 		//Ignore the first byte of data as it's report id
 		if (currentAddress == 0)
 		{
 			data[0] = reportId;
-			eeprom_read_block(&data[1], (uchar *)0 + currentAddress + addressOffset, len - 1);
+			eeprom_read_block(&data[1], (uchar *)0 + addressOffset, len - 1);
 			currentAddress += len - 1;
 			bytesRemaining -= (len - 1);
 		}
@@ -219,7 +223,7 @@ uchar usbFunctionRead(uchar *data, uchar len)
 
        return 6;
     }
-    else if (reportId >= 6 && reportId <= 9) // Serial data for LEDs
+    else if (reportId >= 6 && reportId <= 10) // Serial data for LEDs
     {
        if (bytesRemaining == 0)
        {
@@ -237,7 +241,7 @@ uchar usbFunctionRead(uchar *data, uchar len)
 
           for (int i = 2; i < len; i++)
           {
-              data[i] = led[addressOffset + currentAddress + i - 2];
+              data[i] = led[currentAddress + i - 2];
           }
 
           currentAddress += len - 2;
@@ -247,7 +251,7 @@ uchar usbFunctionRead(uchar *data, uchar len)
        {
           for (int i = 0; i < len; i++)
           {
-              data[i] = led[addressOffset + currentAddress + i];
+              data[i] = led[currentAddress + i];
           }
 
           currentAddress += len;
@@ -311,10 +315,11 @@ uchar usbFunctionWrite(uchar *data, uchar len)
 		if(len > bytesRemaining)
 			len = bytesRemaining;
 
+                uint8_t addressOffset = reportId==2 ? 32 : 64;
 		//Ignore the first byte of data as it's report id
 		if (currentAddress == 0)
 		{
-			eeprom_write_block(&data[1], (uchar *)0 + currentAddress + addressOffset, len);
+			eeprom_write_block(&data[1], (uchar *)0 + addressOffset, len);
 			currentAddress += len - 1;
 			bytesRemaining -= (len - 1);
 		}
@@ -356,7 +361,6 @@ uchar usbFunctionWrite(uchar *data, uchar len)
 		//Prepare to send the data simultaneously together with USB polling
 		task = TASK_SEND_DATA;
 		ledCount = (index + 1) * 3;
-		ledIndex = 0;
 		delayCycles = 0;
 		
 		//Disable any USB requests while sending data to LED Strip
@@ -364,7 +368,7 @@ uchar usbFunctionWrite(uchar *data, uchar len)
 
 		return 1;
 	}
-	else if (reportId >= 6 && reportId <= 9) // Serial data for LEDs
+	else if (reportId >= 6 && reportId <= 10) // Serial data for LEDs
 	{
 		if (mode != MODE_WS2812)
 		{
@@ -373,17 +377,13 @@ uchar usbFunctionWrite(uchar *data, uchar len)
 
 		if (bytesRemaining == 0)
 		{
-			if (reportId != 10)
-			{
-				//Prepare to send the data simultaneously together with USB polling
-				task = TASK_SEND_DATA;
-				ledCount = pgm_read_word_near(&ledDataCount[reportId - 6]);
-				ledIndex = 0;
-				delayCycles = 0;
-				
-				//Disable any USB requests while sending data to LED Strip
-				usbDisableAllRequests();
-			}
+			//Prepare to send the data simultaneously together with USB polling
+			task = TASK_SEND_DATA;
+			ledCount = pgm_read_word_near(&ledDataCount[reportId - 6]);
+			delayCycles = 0;
+			
+			//Disable any USB requests while sending data to LED Strip
+			usbDisableAllRequests();
 
 			return 1; // end of transfer 
 		}
@@ -398,7 +398,7 @@ uchar usbFunctionWrite(uchar *data, uchar len)
 
 			for (int i = 2; i < len; i++)
 			{
-				led[addressOffset + currentAddress + i - 2] = data[i];
+				led[currentAddress + i - 2] = data[i];
 			}
 
 			currentAddress += len - 2;
@@ -408,19 +408,18 @@ uchar usbFunctionWrite(uchar *data, uchar len)
 		{
 			for (int i = 0; i < len; i++)
 			{
-				led[addressOffset + currentAddress + i] = data[i];
+				led[currentAddress + i] = data[i];
 			}
 
 			currentAddress += len;
 			bytesRemaining -= len;
 		}
 
-		if (bytesRemaining <= 0 && reportId != 10)
+		if (bytesRemaining <= 0)
 		{
 			//Prepare to send the data simultaneously together with USB polling
 			task = TASK_SEND_DATA;
 			ledCount = pgm_read_word_near(&ledDataCount[reportId - 6]);
-			ledIndex = 0;
 			delayCycles = 0;
 			
 			//Disable any USB requests while sending data to LED Strip
@@ -489,17 +488,11 @@ extern "C" usbMsgLen_t usbFunctionSetup(uchar data[8])
 			 else if(reportId == 2){ // Name of the device
 				 bytesRemaining = 33;
 				 currentAddress = 0;
-
-				 addressOffset = 32;
-
 				 return USB_NO_MSG; 
 			 }
 			 else if(reportId == 3){ // Data of the device
 				 bytesRemaining = 33;
 				 currentAddress = 0;
-
-				 addressOffset = 64;
-
 				 return USB_NO_MSG; 
 			 }
 			 else if(reportId == 4){ // Report device mode
@@ -508,13 +501,10 @@ extern "C" usbMsgLen_t usbFunctionSetup(uchar data[8])
 			 else if(reportId == 5){ // Indexed LED data^M
 				 currentAddress = 0;
 				 bytesRemaining = 5;
-
-				 addressOffset = 0;
 				 return USB_NO_MSG; 
 			 }
-			 else if (reportId >= 6 && reportId <= 9) { // Serial data for LEDs
+			 else if (reportId >= 6 && reportId <= 10) { // Serial data for LEDs
 			 	currentAddress = 0;
-			 	addressOffset = 0;
 
 			 	switch (reportId) {
 			 	    case 6:
@@ -528,6 +518,9 @@ extern "C" usbMsgLen_t usbFunctionSetup(uchar data[8])
 			 	 	   break;
 			 	    case 9:
 			 	 	   bytesRemaining = MIN_LED_FRAME * 8 + 1;
+			 	 	   break;
+			 	    case 10:
+			 	 	   bytesRemaining = MAX_LEDS*3 + 1;
 			 	 	   break;
 			 	}
 
@@ -547,34 +540,25 @@ extern "C" usbMsgLen_t usbFunctionSetup(uchar data[8])
 			 else if(reportId == 2){ // Name of the device
 				currentAddress = 0;
 				bytesRemaining = 32;
-
-				addressOffset = 32;
 				return USB_NO_MSG; 
 			 }
 			 else if(reportId == 3){ // Name of the device
 				currentAddress = 0;
 				bytesRemaining = 32;
-
-				addressOffset = 64;
 				return USB_NO_MSG; 
 			 }
 			 else if(reportId == 4){ // Mode
 				currentAddress = 0;
 				bytesRemaining = 1;
-
-				addressOffset = 0;
 				return USB_NO_MSG; 
 			 }
 			 else if(reportId == 5){ // Indexed LED data
 				currentAddress = 0;
 				bytesRemaining = 5;
-
-				addressOffset = 0;
 				return USB_NO_MSG; 
 			 }
 			 else if (reportId >= 6 && reportId <= 9) { // Serial data for LEDs
 				 currentAddress = 0;
-				 addressOffset = 0;
 
 				 switch (reportId) {
 					case 6:
@@ -588,6 +572,9 @@ extern "C" usbMsgLen_t usbFunctionSetup(uchar data[8])
 					    break;
 					case 9:
 					    bytesRemaining = MIN_LED_FRAME * 8 + 1;
+					    break;
+					case 10:
+					    bytesRemaining = MAX_LEDS*3 + 1;
 					    break;
 				 }
 
@@ -708,24 +695,19 @@ void ledTransfer() {
 		if (task == TASK_SEND_DATA)
 		{
 			//send all data at the same time, asume there is going to be no communication over USB during this time
-			uint16_t len = 3 * 64;
+			uint16_t len = 3 * MAX_LEDS;
 
-			if (ledIndex + len >= ledCount)
+			if (len > ledCount)
 			{
-				len = ledCount - ledIndex;
+				len = ledCount;
 			}
 
 			cli(); //Disable interrupts
-			ws2812_sendarray_mask(&led[ledIndex], len, channelToPin(channel));
+			ws2812_sendarray_mask(led, len, channelToPin(channel));
 			sei(); //Enable interrupts
 
-			ledIndex += len;
-
-			if (ledIndex >= ledCount - 1)
-			{
-				task = TASK_NONE;
-				usbEnableAllRequests();
-			}
+			task = TASK_NONE;
+			usbEnableAllRequests();
 		}
 		else if (task == TASK_SET_MODE)
 		{
@@ -743,8 +725,6 @@ void ledTransfer() {
 
 int main(void)
 {
-	uchar   i;
-
 	wdt_enable(WDTO_1S);
 
 	SetSerial();
@@ -760,9 +740,8 @@ int main(void)
 
     usbInit();
     usbDeviceDisconnect();  /* enforce re-enumeration, do this while interrupts are disabled! */
-    i = 0;
-    while(--i){             /* fake USB disconnect for > 250 ms */
-		wdt_reset();
+    for(uint8_t i=255; i!=0; i--){  /* fake USB disconnect for > 250 ms */
+	wdt_reset();
         _delay_ms(1);
     }
     usbDeviceConnect();

--- a/main.cpp
+++ b/main.cpp
@@ -120,7 +120,7 @@ const PROGMEM char usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH] 
     '\x09', '\x00',                  //   USAGE (Undefined)
     '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
     '\x85', '\x09',                  //   REPORT_ID (9)
-    '\x96', '\xc1',                  //   REPORT_COUNT (193)
+    '\x95', '\xc1',                  //   REPORT_COUNT (193)
     '\x09', '\x00',                  //   USAGE (Undefined)
     '\xb2', '\x02', '\x01',          //   FEATURE (Data,Var,Abs,Buf)
     '\x85', '\x0a',                  //   REPORT_ID (10)
@@ -557,7 +557,7 @@ extern "C" usbMsgLen_t usbFunctionSetup(uchar data[8])
 				bytesRemaining = 5;
 				return USB_NO_MSG; 
 			 }
-			 else if (reportId >= 6 && reportId <= 9) { // Serial data for LEDs
+			 else if (reportId >= 6 && reportId <= 10) { // Serial data for LEDs
 				 currentAddress = 0;
 
 				 switch (reportId) {

--- a/usbconfig.h
+++ b/usbconfig.h
@@ -256,7 +256,7 @@ section at the end of this file).
  * HID class is 3, no subclass and protocol required (but may be useful!)
  * CDC class is 2, use subclass 2 and protocol 1 for ACM
  */
-#define USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    96
+#define USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    106
 /* Define this to the length of the HID report descriptor, if you implement
  * an HID device. Otherwise don't define it or define it to 0.
  * If you use this define, you must add a PROGMEM character array named

--- a/usbconfig.h
+++ b/usbconfig.h
@@ -256,7 +256,7 @@ section at the end of this file).
  * HID class is 3, no subclass and protocol required (but may be useful!)
  * CDC class is 2, use subclass 2 and protocol 1 for ACM
  */
-#define USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    106
+#define USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    115
 /* Define this to the length of the HID report descriptor, if you implement
  * an HID device. Otherwise don't define it or define it to 0.
  * If you use this define, you must add a PROGMEM character array named


### PR DESCRIPTION
Not sure if this is of interest to you, but I've adapted the pro firmware to support up to 256 LED on a single strip. I added two features to accomplish this:

1. a new report that allows sending data for 128 LED (384 bytes). This strains the memory on the t85, so I also tried to save a few bytes of memory elsewhere
2. a new mode that uses only 12 bits per LED (16 levels for each color) for WS2812. This doubles the amount of LED you can address for each report mode.

I've also adapted the python api to support these features and can submit a PR if you like. The updated firmware should be backwards compatible with old API code since it only adds new modes. I tested this on a BS-pro that I built as well as a Flex I bought from you.